### PR TITLE
Add Read/Fetch and Write/Store metrics to LLM analysis

### DIFF
--- a/GALLERY.md
+++ b/GALLERY.md
@@ -1,0 +1,48 @@
+# Galerie der LLM-Architektur (Llama 3.1 & Transformer)
+
+Diese Galerie enthält 10 ausgewählte Grafiken, die die Struktur und Funktionsweise moderner Large Language Models wie Llama 3.1 illustrieren.
+
+---
+
+### 1. Transformer Hochlevel-Struktur
+![Transformer Hochlevel-Struktur](https://jalammar.github.io/images/t/the_transformer_3.png)
+Eine abstrakte Darstellung des Modells als "Black Box", die Eingabesequenzen verarbeitet und Ausgaben generiert.
+
+### 2. Encoder und Decoder Stacks
+![Encoder und Decoder Stacks](https://jalammar.github.io/images/t/The_transformer_encoder_decoder_stack.png)
+Llama 3 verwendet eine "Decoder-only" Architektur, aber dieses Diagramm zeigt die ursprüngliche Stapelung von Blöcken.
+
+### 3. Der Transformer Encoder Block
+![Transformer Encoder Block](https://jalammar.github.io/images/t/Transformer_encoder.png)
+Detaillierte Ansicht eines einzelnen Blocks mit Self-Attention und Feed-Forward Netzwerken.
+
+### 4. Self-Attention Visualisierung
+![Self-Attention Visualisierung](https://jalammar.github.io/images/t/transformer_self-attention_visualization.png)
+Illustration, wie das Modell beim Kodieren eines Wortes (z.B. "it") Bezüge zu anderen Wörtern im Satz herstellt.
+
+### 5. Self-Attention Vektoren (Q, K, V)
+![Self-Attention Vektoren](https://jalammar.github.io/images/t/transformer_self_attention_vectors.png)
+Darstellung der Query-, Key- und Value-Vektoren, die die Grundlage der Attention-Berechnung bilden.
+
+### 6. Matrix-Berechnung der Self-Attention
+![Matrix-Berechnung der Self-Attention](https://jalammar.github.io/images/t/self-attention-matrix-calculation-2.png)
+Die mathematische Zusammenfassung der Attention-Schritte in effizienter Matrixform.
+
+### 7. Multi-Head Attention Zusammenfassung
+![Multi-Head Attention Zusammenfassung](https://jalammar.github.io/images/t/transformer_multi-headed_self-attention-recap.png)
+Übersicht über die parallele Verarbeitung in mehreren Attention-Heads (Llama 3 nutzt hier GQA).
+
+### 8. Positionale Kodierung (Positional Encoding)
+![Positionale Kodierung](https://jalammar.github.io/images/t/transformer_positional_encoding_large_example.png)
+Visualisierung der Muster, die dem Modell Informationen über die Reihenfolge der Wörter geben.
+
+### 9. Output-Layer: Logits und Softmax
+![Output-Layer](https://jalammar.github.io/images/t/transformer_decoder_output_softmax.png)
+Der Prozess der Umwandlung von Vektoren in Wahrscheinlichkeiten für das nächste Wort im Vokabular.
+
+### 10. Maskierte Self-Attention
+![Maskierte Self-Attention](https://jalammar.github.io/images/t/self-attention-softmax.png)
+Entscheidend für die Inferenz: Das Modell darf bei der Generierung nur auf vergangene, nicht auf zukünftige Tokens schauen.
+
+---
+*Quelle der Grafiken: Jay Alammar (jalammar.github.io)*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ Diese Analyse berechnet die Anzahl der Multiplikationen (MACs), die für die Ver
 | Vokabulargröße | $V$ | 128.256 | Meta Llama 3.1 Paper [[1]] |
 | Kontext-Länge | $N$ | 1.000.000 | Benutzeranfrage |
 
+### 1.1 Erläuterung der Variablen
+
+*   **$L$ (Layer):** Die Anzahl der Transformer-Blöcke (Layer). Jeder Layer führt eine vollständige Sequenz aus Attention- und Feed-Forward-Berechnungen durch. Ein tieferes Modell kann komplexere Zusammenhänge lernen.
+*   **$d_{model}$ (Hidden Dimension):** Die Breite des Modells bzw. die Größe der Vektordarstellung (Embedding) jedes Tokens. Sie bestimmt die Kapazität des Modells, Informationen pro Token zu kodieren.
+*   **$d_{ff}$ (FFN Dimension):** Die Dimension der Zwischenschicht im Feed-Forward-Netzwerk (MLP). Llama 3 nutzt die SwiGLU-Architektur, bei der die Dimension $d_{ff}$ die Größe der versteckten Schichten innerhalb dieses Moduls definiert.
+*   **$h$ (Attention Query Heads):** Die Anzahl der Köpfe für die "Queries" in der Multi-Head Attention. Dies ermöglicht es dem Modell, parallel verschiedene Arten von Abhängigkeiten im Text zu verarbeiten.
+*   **$h_{kv}$ (Attention KV Heads):** Die Anzahl der Köpfe für "Keys" und "Values". Llama 3 verwendet *Grouped-Query Attention* (GQA), wobei sich mehrere Query-Heads einen KV-Head teilen, um die Effizienz (insbesondere den Speicherbedarf) zu erhöhen.
+*   **$V$ (Vokabulargröße):** Die Gesamtanzahl der eindeutigen Tokens, die das Modell in seinem Wörterbuch führt. Dies beeinflusst die Größe der finalen Ausgabeschicht (Unembedding).
+*   **$N$ (Kontext-Länge):** Die Anzahl der Token in der aktuellen Eingabesequenz. Da die Attention-Mechanik quadratisch mit $N$ skaliert, ist dies der kritischste Faktor für die Rechenlast bei langen Texten.
+*   **$d_{head}$ (Head Dimension):** Die Dimension eines einzelnen Attention-Kopfes ($d_{model} / h$). Sie bestimmt die Größe der Vektoren, die im Skalarprodukt der Attention-Berechnung miteinander multipliziert werden.
+
 ---
 
 ## 2. Mathematischer Ablauf und Berechnungsformeln

--- a/analysis_llm.md
+++ b/analysis_llm.md
@@ -25,15 +25,24 @@ In jedem Layer werden die Token in Q, K, V und O projiziert.
 ```math
 MACs_{attn\_proj} = N \cdot (2 \cdot d_{model}^2 + 2 \cdot (d_{model} \cdot d_{head} \cdot h_{kv}))
 ```
-*Hinweis:
 ```math
-d_{head} = d_{model} / h = 128$.*
+Fetch_{attn\_proj} = (2 \cdot d_{model}^2 + 2 \cdot d_{model} \cdot d_{head} \cdot h_{kv}) + (2 \cdot N \cdot d_{model})
 ```
+```math
+Store_{attn\_proj} = 2 \cdot N \cdot d_{model} + 2 \cdot N \cdot d_{head} \cdot h_{kv}
+```
+*Hinweis: $d_{head} = d_{model} / h = 128$.*
 
 ### Schritt B: Attention-Mechanik (Quadratisch)
 Berechnung der Scores ($Q K^T$) und des Kontextvektors ($S V$).
 ```math
 MACs_{attn\_mech} = 2 \cdot (N^2 \cdot d_{model})
+```
+```math
+Fetch_{attn\_mech} = N \cdot (d_{model} + 2 \cdot d_{head} \cdot h_{kv}) + 2 \cdot h \cdot N^2
+```
+```math
+Store_{attn\_mech} = 2 \cdot h \cdot N^2 + N \cdot d_{model}
 ```
 
 ### Schritt C: Feed-Forward Network (MLP)
@@ -41,23 +50,35 @@ Llama nutzt SwiGLU mit drei Matrizen ($W_{gate}, W_{up}, W_{down}$).
 ```math
 MACs_{mlp} = N \cdot (3 \cdot d_{model} \cdot d_{ff})
 ```
+```math
+Fetch_{mlp} = (3 \cdot d_{model} \cdot d_{ff}) + N \cdot (d_{model} + 3 \cdot d_{ff})
+```
+```math
+Store_{mlp} = N \cdot (d_{model} + 3 \cdot d_{ff})
+```
 
 ### Schritt D: Unembedding (Output Layer)
 Projektion des finalen Hidden State auf das Vokabular.
 ```math
 MACs_{output} = N \cdot d_{model} \cdot V
 ```
+```math
+Fetch_{output} = (d_{model} \cdot V) + (N \cdot d_{model})
+```
+```math
+Store_{output} = N \cdot V
+```
 
 ---
 
 ## 3. Berechnung für 1 Million Token ($10^6$)
 
-| Komponente | Formel | Multiplikationen (MACs) |
-| :--- | :--- | :--- |
-| **Linear (Proj + MLP)** | $L \cdot (MACs_{attn\_proj} + MACs_{mlp})$ | $4,02 \cdot 10^{17}$ |
-| **Attention (quadr.)** | $L \cdot MACs_{attn\_mech}$ | $4,13 \cdot 10^{18}$ |
-| **Output Head** | $MACs_{output}$ | $2,10 \cdot 10^{15}$ |
-| **Gesamt** | | **$4,53 \cdot 10^{18}$** |
+| Komponente | Formel | MACs | Read/Fetch (Elem.) | Write/Store (Elem.) |
+| :--- | :--- | :--- | :--- | :--- |
+| **Linear (Proj + MLP)** | $L \cdot (MACs_{attn\_proj} + MACs_{mlp})$ | $4,02 \cdot 10^{17}$ | $2,67 \cdot 10^{13}$ | $2,66 \cdot 10^{13}$ |
+| **Attention (quadr.)** | $L \cdot MACs_{attn\_mech}$ | $4,13 \cdot 10^{18}$ | $3,23 \cdot 10^{16}$ | $3,23 \cdot 10^{16}$ |
+| **Output Head** | $MACs_{output}$ | $2,10 \cdot 10^{15}$ | $1,85 \cdot 10^{10}$ | $1,28 \cdot 10^{11}$ |
+| **Gesamt** | | **$4,53 \cdot 10^{18}$** | **$3,23 \cdot 10^{16}$** | **$3,23 \cdot 10^{16}$** |
 
 ---
 

--- a/calculate_ops.py
+++ b/calculate_ops.py
@@ -1,0 +1,43 @@
+L = 126
+d_model = 16384
+d_ff = 53248
+h = 128
+h_kv = 8
+d_head = 128
+V = 128256
+N = 10**6
+
+# --- linear (Proj + MLP) ---
+# Weights
+w_proj = 2 * d_model**2 + 2 * d_model * d_head * h_kv
+w_mlp = 3 * d_model * d_ff
+weights_linear_total = L * (w_proj + w_mlp)
+
+# Proj Activations
+proj_fetch = 2 * N * d_model # Read X, Read Attn_Out
+proj_store = 2 * N * d_model + 2 * N * d_head * h_kv # Write Q,K,V, Write O_proj
+
+# MLP Activations
+mlp_fetch = N * (d_model + 3 * d_ff) # Read X, Read Gate,Up, Read Intermediate
+mlp_store = N * (d_model + 3 * d_ff) # Write Gate,Up, Write Intermediate, Write Down
+
+linear_fetch = weights_linear_total + L * (proj_fetch + mlp_fetch)
+linear_store = L * (proj_store + mlp_store)
+
+# --- Attention Mechanism ---
+# Fetch Q, K, V activations + Score matrix S (twice: for softmax and SV)
+attn_mech_fetch = L * (N * (d_model + 2 * d_head * h_kv) + 2 * h * N**2)
+# Store S (twice: from QKT and softmax) + Store Context
+attn_mech_store = L * (2 * h * N**2 + N * d_model)
+
+# --- Output Head ---
+w_output = d_model * V
+output_fetch = w_output + N * d_model
+output_store = N * V
+
+print(f"Linear Fetch: {linear_fetch:.2e}")
+print(f"Linear Store: {linear_store:.2e}")
+print(f"Attention Mech Fetch: {attn_mech_fetch:.2e}")
+print(f"Attention Mech Store: {attn_mech_store:.2e}")
+print(f"Output Fetch: {output_fetch:.2e}")
+print(f"Output Store: {output_store:.2e}")


### PR DESCRIPTION
I have expanded the existing LLM processing analysis (`analysis_llm.md`) to include memory bandwidth requirements for Llama 3.1 405B with a 1 million token context. The update includes:
1. **Mathematical Formulas:** Added definitions and formulas for `Fetch` (Read) and `Store` (Write) operations for Linear projections, Attention mechanics, MLP layers, and the Output head.
2. **Calculated Results:** Updated the summary table with the number of elements moved for each step. For 1 million tokens, memory traffic is dominated by the quadratic attention mechanism, requiring approximately $3.23 \cdot 10^{16}$ fetch and store operations.
3. **Verification Script:** Added a Python script `calculate_ops.py` used to derive these numbers from the model's architectural parameters.

The documentation is in German, following the existing language of the file. No code regressions were introduced as this is a documentation-only update.

Fixes #5

---
*PR created automatically by Jules for task [9432874942258848104](https://jules.google.com/task/9432874942258848104) started by @chatelao*