### PR TITLE
Ergänzung der Speicher-I/O-Analyse für Llama 3.1 405B

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ In jedem Layer werden die Token in Q, K, V und O projiziert.
 ```math
 MACs_{attn\_proj} = N \cdot (2 \cdot d_{model}^2 + 2 \cdot (d_{model} \cdot d_{head} \cdot h_{kv}))
 ```
+```math
+Elements_{fetch} = (2 \cdot d_{model}^2 + 2 \cdot (d_{model} \cdot d_{head} \cdot h_{kv})) + N \cdot d_{model}
+```
+```math
+Elements_{store} = N \cdot d_{model}
+```
 *Hinweis:
 ```math
 d_{head} = d_{model} / h = 128$.*
@@ -46,11 +52,23 @@ Berechnung der Scores ($Q K^T$) und des Kontextvektors ($S V$).
 ```math
 MACs_{attn\_mech} = 2 \cdot (N^2 \cdot d_{model})
 ```
+```math
+Elements_{fetch} = N \cdot d_{model} + h \cdot N^2
+```
+```math
+Elements_{store} = h \cdot N^2 + N \cdot d_{model}
+```
 
 ### Schritt C: Feed-Forward Network (MLP)
 Llama nutzt SwiGLU mit drei Matrizen ($W_{gate}, W_{up}, W_{down}$).
 ```math
 MACs_{mlp} = N \cdot (3 \cdot d_{model} \cdot d_{ff})
+```
+```math
+Elements_{fetch} = (3 \cdot d_{model} \cdot d_{ff}) + N \cdot d_{model}
+```
+```math
+Elements_{store} = N \cdot d_{model}
 ```
 
 ### Schritt D: Unembedding (Output Layer)
@@ -58,17 +76,23 @@ Projektion des finalen Hidden State auf das Vokabular.
 ```math
 MACs_{output} = N \cdot d_{model} \cdot V
 ```
+```math
+Elements_{fetch} = (d_{model} \cdot V) + N \cdot d_{model}
+```
+```math
+Elements_{store} = N \cdot V
+```
 
 ---
 
 ## 3. Berechnung für 1 Million Token ($10^6$)
 
-| Komponente | Formel | Multiplikationen (MACs) |
-| :--- | :--- | :--- |
-| **Linear (Proj + MLP)** | $L \cdot (MACs_{attn\_proj} + MACs_{mlp})$ | $4,02 \cdot 10^{17}$ |
-| **Attention (quadr.)** | $L \cdot MACs_{attn\_mech}$ | $4,13 \cdot 10^{18}$ |
-| **Output Head** | $MACs_{output}$ | $2,10 \cdot 10^{15}$ |
-| **Gesamt** | | **$4,53 \cdot 10^{18}$** |
+| Komponente | Formel | Multiplikationen (MACs) | Read/Fetch (Elemente) | Write/Store (Elemente) |
+| :--- | :--- | :--- | :--- | :--- |
+| **Linear (Proj + MLP)** | $L \cdot (MACs_{attn\_proj} + MACs_{mlp})$ | $4,02 \cdot 10^{17}$ | $4,53 \cdot 10^{12}$ | $4,13 \cdot 10^{12}$ |
+| **Attention (quadr.)** | $L \cdot MACs_{attn\_mech}$ | $4,13 \cdot 10^{18}$ | $1,61 \cdot 10^{16}$ | $1,61 \cdot 10^{16}$ |
+| **Output Head** | $MACs_{output}$ | $2,10 \cdot 10^{15}$ | $1,85 \cdot 10^{10}$ | $1,28 \cdot 10^{11}$ |
+| **Gesamt** | | **$4,53 \cdot 10^{18}$** | **$1,61 \cdot 10^{16}$** | **$1,61 \cdot 10^{16}$** |
 
 ---
 

--- a/calc_mem_io.py
+++ b/calc_mem_io.py
@@ -1,0 +1,61 @@
+
+# Model parameters for Llama 3.1 405B
+L = 126
+d_model = 16384
+d_ff = 53248
+h = 128
+h_kv = 8
+V = 128256
+N = 1000000
+d_head = d_model // h
+
+# Step A: Attention Projection
+# Q, K, V, O projections
+w_attn_proj = 2 * d_model**2 + 2 * (d_model * d_head * h_kv)
+macs_a = N * w_attn_proj
+fetch_a = w_attn_proj + N * d_model
+store_a = N * d_model
+
+# Step B: Attention Mechanism
+macs_b = 2 * (N**2 * d_model)
+fetch_b = N * d_model + h * N**2
+store_b = h * N**2 + N * d_model
+
+# Step C: MLP (SwiGLU)
+w_mlp = 3 * d_model * d_ff
+macs_c = N * w_mlp
+fetch_c = w_mlp + N * d_model
+store_c = N * d_model
+
+# Step D: Output Layer
+w_output = d_model * V
+macs_d = N * d_model * V
+fetch_d = w_output + N * d_model
+store_d = N * V
+
+# Totals across all layers
+total_macs_linear = L * (macs_a + macs_c)
+total_macs_attn = L * macs_b
+total_macs_output = macs_d
+total_macs = total_macs_linear + total_macs_attn + total_macs_output
+
+total_fetch_linear = L * (fetch_a + fetch_c)
+total_fetch_attn = L * fetch_b
+total_fetch_output = fetch_d
+total_fetch = total_fetch_linear + total_fetch_attn + total_fetch_output
+
+total_store_linear = L * (store_a + store_c)
+total_store_attn = L * store_b
+total_store_output = store_d
+total_store = total_store_linear + total_store_attn + total_store_output
+
+print(f"Results for N = {N}:")
+print(f"Total MACs: {total_macs:.2e}")
+print(f"Total Fetch: {total_fetch:.2e}")
+print(f"Total Store: {total_store:.2e}")
+print(f"Total I/O: {total_fetch + total_store:.2e}")
+
+print("\nBreakdown per Component (Totals across L layers):")
+print(f"Linear (Proj + MLP): Fetch={total_fetch_linear:.2e}, Store={total_store_linear:.2e}")
+print(f"Attention (quadr.): Fetch={total_fetch_attn:.2e}, Store={total_store_attn:.2e}")
+print(f"Output Head: Fetch={total_fetch_output:.2e}, Store={total_store_output:.2e}")


### PR DESCRIPTION
In dieser Änderung wurde die Analyse der LLM-Verarbeitung (Llama 3.1 405B) um die Anzahl der Read/Fetch und Write/Store Operationen (Elemente) pro Schritt ergänzt. Dazu wurden die mathematischen Formeln für alle Phasen (Attention-Projektionen, Attention-Mechanik, MLP und Output Layer) in Abschnitt 2 der README.md eingefügt. Die Übersichtstabelle in Abschnitt 3 wurde mit den berechneten Werten für eine Sequenzlänge von 1 Million Token aktualisiert. Ein begleitendes Python-Skript (calc_mem_io.py) wurde erstellt, um die mathematische Korrektheit dieser Werte zu validieren. Die Ergebnisse zeigen deutlich, dass die quadratische Attention-Mechanik bei langen Kontexten mit über 99,9% der Speicherzugriffe die I/O-Last dominiert.

Fixes #10

---
*PR created automatically by Jules for task [3758617576418898693](https://jules.google.com/task/3758617576418898693) started by @chatelao*