### PR TITLE
Präzisierung der Memory-I/O-Berechnungen (Read vs. Write)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,12 @@ In jedem Layer werden die Token in Q, K, V und O projiziert.
 MACs_{attn\_proj} = N \cdot (2 \cdot d_{model}^2 + 2 \cdot (d_{model} \cdot d_{head} \cdot h_{kv}))
 ```
 ```math
-Elements_{fetch} = (2 \cdot d_{model}^2 + 2 \cdot (d_{model} \cdot d_{head} \cdot h_{kv})) + N \cdot d_{model}
+Elements_{fetch} = W_{attn\_proj} + 2 \cdot N \cdot d_{model}
 ```
 ```math
-Elements_{store} = N \cdot d_{model}
+Elements_{store} = N \cdot (2 \cdot d_{model} + 2 \cdot d_{head} \cdot h_{kv})
 ```
-*Hinweis:
-```math
-d_{head} = d_{model} / h = 128$.*
-```
+*Hinweis:* $d_{head} = d_{model} / h = 128$. $W_{attn\_proj}$ ist die Anzahl der Gewichte für alle Projektionen.
 
 ### Schritt B: Attention-Mechanik (Quadratisch)
 Berechnung der Scores ($Q K^T$) und des Kontextvektors ($S V$).
@@ -53,7 +50,7 @@ Berechnung der Scores ($Q K^T$) und des Kontextvektors ($S V$).
 MACs_{attn\_mech} = 2 \cdot (N^2 \cdot d_{model})
 ```
 ```math
-Elements_{fetch} = N \cdot d_{model} + h \cdot N^2
+Elements_{fetch} = N \cdot (d_{model} + 2 \cdot d_{head} \cdot h_{kv}) + h \cdot N^2
 ```
 ```math
 Elements_{store} = h \cdot N^2 + N \cdot d_{model}
@@ -65,10 +62,10 @@ Llama nutzt SwiGLU mit drei Matrizen ($W_{gate}, W_{up}, W_{down}$).
 MACs_{mlp} = N \cdot (3 \cdot d_{model} \cdot d_{ff})
 ```
 ```math
-Elements_{fetch} = (3 \cdot d_{model} \cdot d_{ff}) + N \cdot d_{model}
+Elements_{fetch} = W_{mlp} + N \cdot (d_{model} + d_{ff})
 ```
 ```math
-Elements_{store} = N \cdot d_{model}
+Elements_{store} = N \cdot (d_{ff} + d_{model})
 ```
 
 ### Schritt D: Unembedding (Output Layer)
@@ -77,7 +74,7 @@ Projektion des finalen Hidden State auf das Vokabular.
 MACs_{output} = N \cdot d_{model} \cdot V
 ```
 ```math
-Elements_{fetch} = (d_{model} \cdot V) + N \cdot d_{model}
+Elements_{fetch} = W_{output} + N \cdot d_{model}
 ```
 ```math
 Elements_{store} = N \cdot V
@@ -89,10 +86,12 @@ Elements_{store} = N \cdot V
 
 | Komponente | Formel | Multiplikationen (MACs) | Read/Fetch (Elemente) | Write/Store (Elemente) |
 | :--- | :--- | :--- | :--- | :--- |
-| **Linear (Proj + MLP)** | $L \cdot (MACs_{attn\_proj} + MACs_{mlp})$ | $4,02 \cdot 10^{17}$ | $4,53 \cdot 10^{12}$ | $4,13 \cdot 10^{12}$ |
-| **Attention (quadr.)** | $L \cdot MACs_{attn\_mech}$ | $4,13 \cdot 10^{18}$ | $1,61 \cdot 10^{16}$ | $1,61 \cdot 10^{16}$ |
+| **Linear (Proj + MLP)** | $L \cdot (MACs_{attn\_proj} + MACs_{mlp})$ | $4,02 \cdot 10^{17}$ | $1,33 \cdot 10^{13}$ | $1,32 \cdot 10^{13}$ |
+| **Attention (quadr.)** | $L \cdot MACs_{attn\_mech}$ | $4,13 \cdot 10^{18}$ | $1,6130 \cdot 10^{16}$ | $1,6130 \cdot 10^{16}$ |
 | **Output Head** | $MACs_{output}$ | $2,10 \cdot 10^{15}$ | $1,85 \cdot 10^{10}$ | $1,28 \cdot 10^{11}$ |
-| **Gesamt** | | **$4,53 \cdot 10^{18}$** | **$1,61 \cdot 10^{16}$** | **$1,61 \cdot 10^{16}$** |
+| **Gesamt** | | **$4,53 \cdot 10^{18}$** | **$1,6144 \cdot 10^{16}$** | **$1,6143 \cdot 10^{16}$** |
+
+*Hinweis: In der Gesamtübersicht weichen Read und Write geringfügig voneinander ab, da Zwischenergebnisse (Aktivierungen) unterschiedlich oft gelesen und geschrieben werden. Bei der quadratischen Attention sind die Werte so groß, dass der Unterschied erst in den hinteren Nachkommastellen (ab der 5. Stelle) sichtbar wird.*
 
 ---
 

--- a/calc_mem_io.py
+++ b/calc_mem_io.py
@@ -9,29 +9,70 @@ V = 128256
 N = 1000000
 d_head = d_model // h
 
-# Step A: Attention Projection
-# Q, K, V, O projections
-w_attn_proj = 2 * d_model**2 + 2 * (d_model * d_head * h_kv)
+# Step A: Attention Projection (Q, K, V, O)
+# Weights
+w_q = d_model**2
+w_k = d_model * (d_head * h_kv)
+w_v = d_model * (d_head * h_kv)
+w_o = d_model**2
+w_attn_proj = w_q + w_k + w_v + w_o
+
 macs_a = N * w_attn_proj
-fetch_a = w_attn_proj + N * d_model
-store_a = N * d_model
+
+# Activations
+act_q = N * d_model
+act_k = N * (d_head * h_kv)
+act_v = N * (d_head * h_kv)
+act_attn_out = N * d_model # Output of Attention Mechanism (Input to O-Proj)
+act_x = N * d_model # Input to the whole layer
+act_o = N * d_model # Output of O-Proj
+
+# Fetch: Weights + Input + Attn_out (for O-proj)
+fetch_a = w_attn_proj + act_x + act_attn_out
+# Store: Q, K, V + Final O
+store_a = act_q + act_k + act_v + act_o
 
 # Step B: Attention Mechanism
-macs_b = 2 * (N**2 * d_model)
-fetch_b = N * d_model + h * N**2
-store_b = h * N**2 + N * d_model
+# QK^T -> Scores
+macs_b1 = N**2 * d_model # (N x d) * (d x N) per head? No, sum over heads.
+# Actually MACs for QK^T: N * N * d_head * h = N^2 * d_model
+# Softmax and context: Scores * V -> Context
+macs_b2 = N**2 * d_model
+
+macs_b = macs_b1 + macs_b2
+
+# Memory I/O
+act_scores = h * N**2
+# Fetch: Q, K + Scores (for V-mult) + V
+fetch_b = act_q + act_k + act_scores + act_v
+# Store: Scores + AttnOut
+store_b = act_scores + act_attn_out
 
 # Step C: MLP (SwiGLU)
+# Weights: Gate, Up, Down
 w_mlp = 3 * d_model * d_ff
 macs_c = N * w_mlp
-fetch_c = w_mlp + N * d_model
-store_c = N * d_model
+
+act_mlp_in = N * d_model
+act_mlp_hidden = N * d_ff # Intermediate activation after Gate/Up
+act_mlp_out = N * d_model
+
+# Fetch: Weights + Input + Hidden (for Down-proj)
+fetch_c = w_mlp + act_mlp_in + act_mlp_hidden
+# Store: Hidden + Output
+store_c = act_mlp_hidden + act_mlp_out
 
 # Step D: Output Layer
 w_output = d_model * V
 macs_d = N * d_model * V
-fetch_d = w_output + N * d_model
-store_d = N * V
+
+act_final_in = N * d_model
+act_logits = N * V
+
+# Fetch: Weights + Input
+fetch_d = w_output + act_final_in
+# Store: Logits
+store_d = act_logits
 
 # Totals across all layers
 total_macs_linear = L * (macs_a + macs_c)
@@ -50,12 +91,12 @@ total_store_output = store_d
 total_store = total_store_linear + total_store_attn + total_store_output
 
 print(f"Results for N = {N}:")
-print(f"Total MACs: {total_macs:.2e}")
-print(f"Total Fetch: {total_fetch:.2e}")
-print(f"Total Store: {total_store:.2e}")
-print(f"Total I/O: {total_fetch + total_store:.2e}")
+print(f"Total MACs: {total_macs:.6e}")
+print(f"Total Fetch: {total_fetch:.6e}")
+print(f"Total Store: {total_store:.6e}")
+print(f"Total I/O: {total_fetch + total_store:.6e}")
 
 print("\nBreakdown per Component (Totals across L layers):")
-print(f"Linear (Proj + MLP): Fetch={total_fetch_linear:.2e}, Store={total_store_linear:.2e}")
-print(f"Attention (quadr.): Fetch={total_fetch_attn:.2e}, Store={total_store_attn:.2e}")
-print(f"Output Head: Fetch={total_fetch_output:.2e}, Store={total_store_output:.2e}")
+print(f"Linear (Proj + MLP): Fetch={total_fetch_linear:.6e}, Store={total_store_linear:.6e}")
+print(f"Attention (quadr.): Fetch={total_fetch_attn:.6e}, Store={total_store_attn:.6e}")
+print(f"Output Head: Fetch={total_fetch_output:.6e}, Store={total_store_output:.6e}")


### PR DESCRIPTION
Nein, es werden nicht exakt gleich viele Werte geschrieben wie geladen, auch wenn sie in der vorherigen Rundung identisch erschienen.

### Analyse der Unterschiede:
1. **Zusätzliche Fetch-Operationen (Gewichte):** Bei fast jedem Schritt müssen die Modellgewichte geladen werden, was nur auf der „Fetch“-Seite zählt.
2. **Zwischenergebnisse (Aktivierungen):** In der modernisierten Berechnung werden Aktivierungen wie die $Q, K, V$-Vektoren, die quadratische Score-Matrix ($h \cdot N^2$) und der MLP-Zwischenzustand (SwiGLU) explizit berücksichtigt. Manche dieser Werte werden einmal geschrieben und später wieder gelesen, was die I/O-Bilanz beeinflusst.
3. **Beispielrechnung (N=1M):**
   - **Total Fetch:** $1,6144 \cdot 10^{16}$ Elemente
   - **Total Store:** $1,6143 \cdot 10^{16}$ Elemente

Die Dominanz der quadratischen Attention ($N^2$) führt dazu, dass beide Werte extrem nah beieinander liegen, da die Score-Matrix sowohl geschrieben als auch sofort wieder gelesen werden muss. Der Unterschied wird erst ab der 5. Nachkommastelle deutlich.

Die `README.md` und das Skript `calc_mem_io.py` wurden aktualisiert, um diese präziseren Formeln und Werte widerzuspiegeln.

Fixes #16

---
*PR created automatically by Jules for task [9951541206908601619](https://jules.google.com/task/9951541206908601619) started by @chatelao*